### PR TITLE
Fix word wrap in mfsa2015-08

### DIFF
--- a/announce/2015/mfsa2015-08.md
+++ b/announce/2015/mfsa2015-08.md
@@ -5,8 +5,7 @@ fixed_in:
 - SeaMonkey 2.32
 impact: Low
 reporter: Brian Smith
-title: Delegated OCSP responder certificates failure with id-pkix-ocsp-nocheck
-extension
+title: Delegated OCSP responder certificates failure with id-pkix-ocsp-nocheck extension
 ---
 
 <h3>Description</h3>


### PR DESCRIPTION
In YAML a wrapped paragraph has to line up
indents. YAML was interpreting "extension" as a new
key without a ":" and was erroring.