### PR TITLE
Please merge my cleanup commits (rebased version of closed pull request #3)

### DIFF
--- a/announce/2005/mfsa2005-57.md
+++ b/announce/2005/mfsa2005-57.md
@@ -5,8 +5,7 @@ fixed_in:
 - Mozilla Suite 1.7.12
 impact: Critical
 reporter: Tom Ferris
-title: <abbr title="Internationalized Domain Name">IDN</abbr> heap overrun using soft-hyphensheap
-  overrun using soft-hyphens
+title: <abbr title="Internationalized Domain Name">IDN</abbr> heap overrun using soft-hyphensheap overrun using soft-hyphens
 ---
 
 <h3>Description</h3>

--- a/announce/2005/mfsa2005-57.md
+++ b/announce/2005/mfsa2005-57.md
@@ -5,7 +5,7 @@ fixed_in:
 - Mozilla Suite 1.7.12
 impact: Critical
 reporter: Tom Ferris
-title: <abbr title="Internationalized Domain Name">IDN</abbr> heap overrun using soft-hyphensheap overrun using soft-hyphens
+title: <abbr title="Internationalized Domain Name">IDN</abbr> heap overrun using soft-hyphens
 ---
 
 <h3>Description</h3>

--- a/announce/2006/mfsa2006-30.md
+++ b/announce/2006/mfsa2006-30.md
@@ -1,8 +1,9 @@
 ---
-affects: Firefox 1.5
 announced: May 2, 2006
 fixed_in:
 - Firefox 1.5.0.3
+vulnerable:
+- Firefox 1.5
 impact: Critical
 reporter: Martijn Wargers, Nick Mott, splices
 title: Deleted object reference when designMode="on"

--- a/announce/2007/mfsa2007-10.md
+++ b/announce/2007/mfsa2007-10.md
@@ -1,6 +1,5 @@
 ---
 announced: March 5, 2007
-fix_released: March 1, 2007
 fixed_in:
 - Thunderbird 1.5.0.10
 - SeaMonkey 1.0.8

--- a/announce/2007/mfsa2007-38.md
+++ b/announce/2007/mfsa2007-38.md
@@ -19,7 +19,7 @@ could be exploited to run arbitrary code.
 <h3>References</h3>
 
 <ul>
-  <li><a href="https://bugzilla.mozilla.org/buglist.cgi?bug_id=373911%2C391028%2C393326">
+  <li><a href="https://bugzilla.mozilla.org/buglist.cgi?bug_id=373911,391028,393326">
        Memory corruption bugs fixed in 1.8.1.10</a></li>
 
   <li><a class="ex-ref" href="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2007-5959">

--- a/announce/2011/mfsa2011-17.md
+++ b/announce/2011/mfsa2011-17.md
@@ -36,7 +36,7 @@ potentially exploitable buffer overflow in the WebGLES library</p>
 in the WebGLES library to the Chrome Secuity Team. We thank them for
 coordinating with us on this fix.</p>
 <ul>
-  <li><a href="https://bugzilla.mozilla.org/show_bug.cgi?id=623791#c6">
+  <li><a href="https://bugzilla.mozilla.org/show_bug.cgi?id=623791">
       https://bugzilla.mozilla.org/show_bug.cgi?id=623791</a></li>
   <li><a href="http://code.google.com/p/chromium/issues/detail?id=78524" class="ex-ref">Chromium bug 78524</a></li>
   <li><a href="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2011-1300" class="ex-ref">CVE-2011-1300</a></li>

--- a/announce/2011/mfsa2011-17.md
+++ b/announce/2011/mfsa2011-17.md
@@ -36,7 +36,7 @@ potentially exploitable buffer overflow in the WebGLES library</p>
 in the WebGLES library to the Chrome Secuity Team. We thank them for
 coordinating with us on this fix.</p>
 <ul>
-  <li><a href="https://bugzilla.mozilla.org/show_bug.cgi?id=623791">
+  <li><a href="https://bugzilla.mozilla.org/show_bug.cgi?id=623791#c6">
       https://bugzilla.mozilla.org/show_bug.cgi?id=623791</a></li>
   <li><a href="http://code.google.com/p/chromium/issues/detail?id=78524" class="ex-ref">Chromium bug 78524</a></li>
   <li><a href="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2011-1300" class="ex-ref">CVE-2011-1300</a></li>

--- a/announce/2012/mfsa2012-01.md
+++ b/announce/2012/mfsa2012-01.md
@@ -28,7 +28,7 @@ least some of these could be exploited to run arbitrary code.</p>
 Jan Odvarko, Peter Van Der Beken, and Bill McCloskey reported memory safety
 problems that were fixed in Firefox 10.</p>
 <ul>
-  <li><a href="https://bugzilla.mozilla.org/buglist.cgi?bug_id=695076,696748,712169,&#10;713209,714600,692817,715662,665578,711651,712289,684938,707051">
+  <li><a href="https://bugzilla.mozilla.org/buglist.cgi?bug_id=695076,696748,712169,713209,714600,692817,715662,665578,711651,712289,684938,707051">
           Memory safety bugs fixed in Firefox 10</a></li>
   <li><a href="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2012-0443" class="ex-ref">CVE-2012-0443</a></li>
 </ul>

--- a/announce/2012/mfsa2012-19.md
+++ b/announce/2012/mfsa2012-19.md
@@ -41,7 +41,7 @@ Firefox 3.6</a></li>
 Anderson reported memory safety problems and crashes that affect Firefox ESR and
 Firefox 10.</p>
 <ul>
-  <li><a href="https://bugzilla.mozilla.org/buglist.cgi?bug_id=699033,714590,718202,&#10;718516,701269,712572,727330,720380,705855">
+  <li><a href="https://bugzilla.mozilla.org/buglist.cgi?bug_id=699033,714590,718202,718516,701269,712572,727330,720380,705855">
           Memory safety bugs fixed in Firefox 11 and Firefox ESR 10.0.3</a></li>
   <li><a href="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2012-0462" class="ex-ref">CVE-2012-0462</a></li>
 </ul>

--- a/announce/2012/mfsa2012-20.md
+++ b/announce/2012/mfsa2012-20.md
@@ -40,7 +40,7 @@ Hall, Honza Bambas, Jesse Ruderman, Julian Seward, and Olli Pettay reported
 memory safety problems and crashes that affect Firefox ESR and
 Firefox 11.</p>
 <ul>
-  <li><a href="https://bugzilla.mozilla.org/buglist.cgi?bug_id=706381,733282,737129,&#10;737875,714614,732941,732951,733979,737384,737875,680456,735073,736609,740595,&#10;737182,716556,708825,720305,735943,736589,723453,726332,726502">
+  <li><a href="https://bugzilla.mozilla.org/buglist.cgi?bug_id=706381,733282,737129,737875,714614,732941,732951,733979,737384,737875,680456,735073,736609,740595,737182,716556,708825,720305,735943,736589,723453,726332,726502">
           Memory safety bugs fixed in Firefox 12 and Firefox ESR 10.0.4</a></li>
   <li><a href="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2012-0467" class="ex-ref">CVE-2012-0467</a></li>
 </ul>

--- a/announce/2012/mfsa2012-42.md
+++ b/announce/2012/mfsa2012-42.md
@@ -30,7 +30,7 @@ in browser or browser-like contexts in those products.</p>
 Chris Jones, Brad Lassey, and Kyle Huey reported memory safety problems and crashes that
 affect Firefox 13.</p>
 <ul>
-  <li><a href="https://bugzilla.mozilla.org/buglist.cgi?bug_id=712914,738841,743876,&#10;754725,757431,717488,718290,752662,765179,766018,766304,725499">
+  <li><a href="https://bugzilla.mozilla.org/buglist.cgi?bug_id=712914,738841,743876,754725,757431,717488,718290,752662,765179,766018,766304,725499">
           Memory safety bugs fixed in Firefox 14</a></li>
   <li><a href="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2012-1949" class="ex-ref">CVE-2012-1949</a></li>
 </ul>
@@ -40,7 +40,7 @@ memory safety problems and crashes that affect Firefox ESR 10 and
 Firefox 13.</p>
 
 <ul>
-  <li><a href="https://bugzilla.mozilla.org/buglist.cgi?bug_id=732233,746896,&#10;750575,763225,746103,756600,749385,758471,754989,772282">
+  <li><a href="https://bugzilla.mozilla.org/buglist.cgi?bug_id=732233,746896,750575,763225,746103,756600,749385,758471,754989,772282">
           Memory safety bugs fixed in Firefox ESR 10.0.6 and Firefox 14</a></li>
   <li><a href="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2012-1948" class="ex-ref">CVE-2012-1948</a></li>
 </ul>

--- a/announce/2012/mfsa2012-57.md
+++ b/announce/2012/mfsa2012-57.md
@@ -30,7 +30,7 @@ in browser or browser-like contexts in those products.</p>
 Sutherland reported memory safety problems and crashes that
 affect Firefox 14.</p>
 <ul>
-  <li><a href="https://bugzilla.mozilla.org/buglist.cgi?bug_id=719750,748119,749039,&#10;754150,754242,732870,752038,753162,755916,780712,730208,779849,752087,765936">
+  <li><a href="https://bugzilla.mozilla.org/buglist.cgi?bug_id=719750,748119,749039,754150,754242,732870,752038,753162,755916,780712,730208,779849,752087,765936">
           Memory safety bugs fixed in Firefox 15</a></li>
   <li><a href="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2012-1971" class="ex-ref">CVE-2012-1971</a></li>
 </ul>
@@ -39,7 +39,7 @@ affect Firefox 14.</p>
 Vukicevic, Daniel Holbert, and Jason Smith reported memory safety problems and crashes that affect Firefox ESR 10 and Firefox 14.</p>
 
 <ul>
-  <li><a href="https://bugzilla.mozilla.org/buglist.cgi?bug_id=745158,758408,761831,&#10;764176,777806,775206,778765,773097">
+  <li><a href="https://bugzilla.mozilla.org/buglist.cgi?bug_id=745158,758408,761831,764176,777806,775206,778765,773097">
           Memory safety bugs fixed in Firefox ESR 10.0.7 and Firefox 15</a></li>
   <li><a href="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2012-1970" class="ex-ref">CVE-2012-1970</a></li>
 </ul>

--- a/announce/2012/mfsa2012-59.md
+++ b/announce/2012/mfsa2012-59.md
@@ -16,7 +16,7 @@ title: Location object can be shadowed using Object.defineProperty
 <p>Security researcher <strong>Mariusz Mlynski</strong> reported that it is possible to shadow the location object using Object.defineProperty. This could be used to confuse the current location to plugins, allowing for possible cross-site scripting (XSS) attacks.
 </p>
 
-<p><strong>Update October 9, 2012</strong>: This advisory was updated to reflect the fact that <a href="&lt;a href=" https:="">bug 756719</a> was also fixed in ESR 10.0.8.
+<p><strong>Update October 9, 2012</strong>: This advisory was updated to reflect the fact that <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=756719">bug 756719</a> was also fixed in ESR 10.0.8.
 
 
 </p><h3>References</h3>

--- a/announce/2012/mfsa2012-74.md
+++ b/announce/2012/mfsa2012-74.md
@@ -29,7 +29,7 @@ in browser or browser-like contexts in those products.</p>
 <p>Henrik Skupin, Jesse Ruderman and moz_bug_r_a4 reported memory safety
 problems and crashes that affect Firefox 15.</p>
 <ul>
-  <li><a href="https://bugzilla.mozilla.org/buglist.cgi?bug_id=634444,790865,768313,&#10;762920">
+  <li><a href="https://bugzilla.mozilla.org/buglist.cgi?bug_id=634444,790865,768313,762920">
           Memory safety bugs fixed in Firefox 16</a></li>
   <li><a href="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2012-3983" class="ex-ref">CVE-2012-3983</a></li>
 </ul>

--- a/announce/2013/mfsa2013-104.md
+++ b/announce/2013/mfsa2013-104.md
@@ -28,7 +28,7 @@ memory safety problems and crashes that affect Firefox ESR 24.1 and Firefox
 25.</p>
 
 <ul>
-  <li><a href="https://bugzilla.mozilla.org/buglist.cgi?bug_id=886850,937582,922009,&#10;905382">
+  <li><a href="https://bugzilla.mozilla.org/buglist.cgi?bug_id=886850,937582,922009,905382">
           Memory safety bugs fixed in Firefox ESR 24.2 and Firefox 26.0</a> (<a href="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2013-5609" class="ex-ref">CVE-2013-5609</a>)</li>
 </ul>
 

--- a/announce/2013/mfsa2013-21.md
+++ b/announce/2013/mfsa2013-21.md
@@ -31,7 +31,7 @@ Joe Drew, and Wayne Mery reported memory safety problems and crashes that affect
 Firefox ESR 17, and Firefox 18.</p>
 
 <ul>
-  <li><a href="https://bugzilla.mozilla.org/buglist.cgi?bug_id=830975,832162,822858,&#10;761448,812380,690970,826471,830399,818241,780549">
+  <li><a href="https://bugzilla.mozilla.org/buglist.cgi?bug_id=830975,832162,822858,761448,812380,690970,826471,830399,818241,780549">
           Memory safety bugs fixed in Firefox ESR 17.0.3, and Firefox 19</a> (<a href="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2013-0783" class="ex-ref">CVE-2013-0783</a>)</li>
 </ul>
 
@@ -39,7 +39,7 @@ Firefox ESR 17, and Firefox 18.</p>
 Terrence Cole, Timothy Nikkel, Olli Pettay, Bill McCloskey, and Nicolas Pierron
 reported memory safety problems and crashes that affect Firefox 18.</p>
 <ul>
-  <li><a href="https://bugzilla.mozilla.org/buglist.cgi?bug_id=830943,799803,799907,&#10;819635,766452,827687,805294,801114,790373,809295,810169,797977">
+  <li><a href="https://bugzilla.mozilla.org/buglist.cgi?bug_id=830943,799803,799907,819635,766452,827687,805294,801114,790373,809295,810169,797977">
           Memory safety bugs fixed in Firefox 19</a> (<a href="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2013-0784" class="ex-ref">CVE-2013-0784</a>)</li>
 </ul>
 

--- a/announce/2013/mfsa2013-30.md
+++ b/announce/2013/mfsa2013-30.md
@@ -31,7 +31,7 @@ Sreckovic, and Joe Drew reported memory safety problems and crashes that affect
 Firefox ESR 17, and Firefox 19.</p>
 
 <ul>
-  <li><a href="https://bugzilla.mozilla.org/buglist.cgi?bug_id=635852,771942,784730,&#10;813442,827870,834240,839621,840263,840353,852923">
+  <li><a href="https://bugzilla.mozilla.org/buglist.cgi?bug_id=635852,771942,784730,813442,827870,834240,839621,840263,840353,852923">
           Memory safety bugs fixed in Firefox 17.0.5 and Firefox 20.0</a> (<a href="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2013-0788" class="ex-ref">CVE-2013-0788</a>)</li>
 </ul>
 
@@ -40,7 +40,7 @@ Holler, and Mats Palmgren reported memory safety problems and crashes that
 affect Firefox 19.</p>
 
 <ul>
-  <li><a href="https://bugzilla.mozilla.org/buglist.cgi?bug_id=808736,830595,817841,&#10;824643,824856,831055,849014,827596,835499,837714,839209,842300,815315">
+  <li><a href="https://bugzilla.mozilla.org/buglist.cgi?bug_id=808736,830595,817841,824643,824856,831055,849014,827596,835499,837714,839209,842300,815315">
           Memory safety bugs fixed in Firefox 20.0</a> (<a href="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2013-0789" class="ex-ref">CVE-2013-0789</a>)</li>
 </ul>
 

--- a/announce/2013/mfsa2013-41.md
+++ b/announce/2013/mfsa2013-41.md
@@ -30,7 +30,7 @@ Walden reported memory safety problems and crashes that affect Firefox ESR 17,
 and Firefox 20.</p>
 
 <ul>
-  <li><a href="https://bugzilla.mozilla.org/buglist.cgi?bug_id=808402,787283,849597,&#10;866544,852315,864558">
+  <li><a href="https://bugzilla.mozilla.org/buglist.cgi?bug_id=808402,787283,849597,866544,852315,864558">
           Memory safety bugs fixed in Firefox 17.0.6 and Firefox 21.0</a> (<a href="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2013-0801" class="ex-ref">CVE-2013-0801</a>)</li>
 </ul>
 
@@ -40,7 +40,7 @@ Wobensmith, and Mats Palmgren reported memory safety problems and crashes that
 affect Firefox 20.</p>
 
 <ul>
-  <li><a href="https://bugzilla.mozilla.org/buglist.cgi?bug_id=803228,834526,791432,&#10;865948,821850,837324,814552,826392,826588,855236,819775,822910,837007,843434,&#10;821479,826104,854001">
+  <li><a href="https://bugzilla.mozilla.org/buglist.cgi?bug_id=803228,834526,791432,865948,821850,837324,814552,826392,826588,855236,819775,822910,837007,843434,821479,826104,854001">
           Memory safety bugs fixed in Firefox 21.0</a> (<a href="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2013-1669" class="ex-ref">CVE-2013-1669</a>)</li>
 </ul>
 

--- a/announce/2013/mfsa2013-63.md
+++ b/announce/2013/mfsa2013-63.md
@@ -38,7 +38,7 @@ that affect Firefox ESR 17, and Firefox 22.</p>
 affect Firefox 22.</p>
 
 <ul>
-  <li><a href="https://bugzilla.mozilla.org/buglist.cgi?bug_id=855331,844088,858060,&#10;870200,874974,861530,854157,893684,878703,862185,879139">
+  <li><a href="https://bugzilla.mozilla.org/buglist.cgi?bug_id=855331,844088,858060,870200,874974,861530,854157,893684,878703,862185,879139">
           Memory safety bugs fixed in Firefox 23.0</a> (<a href="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2013-1702" class="ex-ref">CVE-2013-1702</a>)</li>
 </ul>
 

--- a/announce/2013/mfsa2013-76.md
+++ b/announce/2013/mfsa2013-76.md
@@ -38,7 +38,7 @@ Gary Kwong, Scoobidiver, Olli Pettay, Bobby Holley, and Bob Clary reported memor
 safety problems and crashes that affect Firefox 23.</p>
 
 <ul>
-  <li><a href="https://bugzilla.mozilla.org/buglist.cgi?bug_id=750932,871462,847606,&#10;863935,893519,895294,876878,898381,896126,898832,873073,854897,851982,883450,909494">
+  <li><a href="https://bugzilla.mozilla.org/buglist.cgi?bug_id=750932,871462,847606,863935,893519,895294,876878,898381,896126,898832,873073,854897,851982,883450,909494">
           Memory safety bugs fixed in Firefox 24.0</a> (<a href="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2013-1719" class="ex-ref">CVE-2013-1719</a>)</li>
 </ul>
 

--- a/announce/2013/mfsa2013-93.md
+++ b/announce/2013/mfsa2013-93.md
@@ -47,7 +47,7 @@ Firefox 25.0</a> (<a href="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-201
 problems and crashes that affect Firefox 24.</p>
 
 <ul>
-  <li><a href="https://bugzilla.mozilla.org/buglist.cgi?bug_id=880544,886102,887921,&#10;912534">
+  <li><a href="https://bugzilla.mozilla.org/buglist.cgi?bug_id=880544,886102,887921,912534">
           Memory safety bugs fixed in Firefox 25.0</a> (<a href="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2013-5592" class="ex-ref">CVE-2013-5592</a>)</li>
 </ul>
 

--- a/announce/2014/mfsa2014-01.md
+++ b/announce/2014/mfsa2014-01.md
@@ -29,7 +29,7 @@ reported memory safety problems and crashes that affect Firefox ESR 24.2 and
 Firefox 26.</p>
 
 <ul>
-  <li><a href="https://bugzilla.mozilla.org/buglist.cgi?bug_id=921470,937697,951366,&#10;953114,945939,950000,950438,925896,937132,936808,945334">
+  <li><a href="https://bugzilla.mozilla.org/buglist.cgi?bug_id=921470,937697,951366,953114,945939,950000,950438,925896,937132,936808,945334">
           Memory safety bugs fixed in Firefox ESR 24.3 and Firefox 27.0</a> (<a href="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2014-1477" class="ex-ref">CVE-2014-1477</a>)</li>
 </ul>
 
@@ -40,7 +40,7 @@ Seward, and Dan Gohman reported memory safety problems and crashes that affect
 Firefox 26.</p>
 
 <ul>
-  <li><a href="https://bugzilla.mozilla.org/buglist.cgi?bug_id=944321,911707,938431,&#10;944278,922603,925308,950452,939472,944851,924348,932162,942940,945585,&#10;946733,953373,867597,911845,916635">
+  <li><a href="https://bugzilla.mozilla.org/buglist.cgi?bug_id=944321,911707,938431,944278,922603,925308,950452,939472,944851,924348,932162,942940,945585,946733,953373,867597,911845,916635">
           Memory safety bugs fixed in Firefox 27.0</a> (<a href="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2014-1478" class="ex-ref">CVE-2014-1478</a>)</li>
 </ul>
 

--- a/announce/2014/mfsa2014-15.md
+++ b/announce/2014/mfsa2014-15.md
@@ -26,7 +26,7 @@ potentially a risk in browser or browser-like contexts.</p>
 <p>Benoit Jacob, Olli Pettay, Jan Varga, Jan de Mooij, Jesse Ruderman, Dan Gohman, and Christoph Diehl reported memory safety problems and crashes that affect Firefox ESR 24.3 and Firefox 27.</p>
 
 <ul>
-  <li><a href="https://bugzilla.mozilla.org/buglist.cgi?bug_id=963974,958867,965982,&#10;977538,967341,960145,896268">
+  <li><a href="https://bugzilla.mozilla.org/buglist.cgi?bug_id=963974,958867,965982,977538,967341,960145,896268">
           Memory safety bugs fixed in Firefox ESR 24.4 and Firefox 28.0</a> (<a href="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2014-1493" class="ex-ref">CVE-2014-1493</a>)</li>
 </ul>
 

--- a/announce/2014/mfsa2014-34.md
+++ b/announce/2014/mfsa2014-34.md
@@ -31,7 +31,7 @@ Ruderman, Nathan Froyd, and Christian Holler reported memory safety problems and
 crashes that affect Firefox ESR 24.4 and Firefox 28.</p>
 
 <ul>
-  <li><a href="https://bugzilla.mozilla.org/buglist.cgi?bug_id=986843,944353,966630,&#10;952022,986678,980537,991471,993546,992968">
+  <li><a href="https://bugzilla.mozilla.org/buglist.cgi?bug_id=986843,944353,966630,952022,986678,980537,991471,993546,992968">
           Memory safety bugs fixed in Firefox ESR 24.5 and Firefox 29.0</a> (<a href="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2014-1518" class="ex-ref">CVE-2014-1518</a>)</li>
 </ul>
 
@@ -41,7 +41,7 @@ Vladimir Vukicevic, and Jan de Mooij reported memory safety problems and crashes
 that affect Firefox 28.</p>
 
 <ul>
-  <li><a href="https://bugzilla.mozilla.org/buglist.cgi?bug_id=946658,953104,996883,&#10;986864,977955,990794,919592,995607">
+  <li><a href="https://bugzilla.mozilla.org/buglist.cgi?bug_id=946658,953104,996883,986864,977955,990794,919592,995607">
           Memory safety bugs fixed in Firefox 29.0</a> (<a href="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2014-1519" class="ex-ref">CVE-2014-1519</a>)</li>
 </ul>
 

--- a/announce/2014/mfsa2014-48.md
+++ b/announce/2014/mfsa2014-48.md
@@ -25,7 +25,7 @@ Mooij, Ryan VanderMeulen, Jeff Walden, and Kyle Huey reported memory safety
 problems and crashes that affect Firefox ESR 24.5 and Firefox 29.</p>
 
 <ul>
-  <li><a href="https://bugzilla.mozilla.org/buglist.cgi?bug_id=988719,995679,967354,&#10;978811,996715,992274,1011007,921622,1009952,991981,999651,994907">
+  <li><a href="https://bugzilla.mozilla.org/buglist.cgi?bug_id=988719,995679,967354,978811,996715,992274,1011007,921622,1009952,991981,999651,994907">
           Memory safety bugs fixed in Firefox ESR 24.6 and Firefox 30.0</a> (<a href="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2014-1533" class="ex-ref">CVE-2014-1533</a>)</li>
 </ul>
 
@@ -35,7 +35,7 @@ Karl Tomlinson, and Jeff Walden reported memory safety problems and crashes that
 affect Firefox 29.</p>
 
 <ul>
-  <li><a href="https://bugzilla.mozilla.org/buglist.cgi?bug_id=995816,995817,978652,&#10;1002340,1005578,973874,996536,1000960,1000598,969517,969549,990868,1007223">
+  <li><a href="https://bugzilla.mozilla.org/buglist.cgi?bug_id=995816,995817,978652,1002340,1005578,973874,996536,1000960,1000598,969517,969549,990868,1007223">
           Memory safety bugs fixed in Firefox 30.0</a> (<a href="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2014-1534" class="ex-ref">CVE-2014-1534</a>)</li>
 </ul>
 

--- a/announce/2014/mfsa2014-56.md
+++ b/announce/2014/mfsa2014-56.md
@@ -38,7 +38,7 @@ and Cătălin Badea reported memory safety problems and crashes that affect
 Firefox 30.</p>
 
 <ul>
-  <li><a href="https://bugzilla.mozilla.org/buglist.cgi?bug_id=990096,1013056,1034383,&#10;1035438,1002702,1020041,1020008,1009675,1021312,1020219,994444,1022773,1028358,1021969,1021240">
+  <li><a href="https://bugzilla.mozilla.org/buglist.cgi?bug_id=990096,1013056,1034383,1035438,1002702,1020041,1020008,1009675,1021312,1020219,994444,1022773,1028358,1021969,1021240">
           Memory safety bugs fixed in Firefox 31.0</a> (<a href="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2014-1548" class="ex-ref">CVE-2014-1548</a>)</li>
 </ul>
 

--- a/announce/2014/mfsa2014-67.md
+++ b/announce/2014/mfsa2014-67.md
@@ -40,7 +40,7 @@ Jesse Ruderman, and JW Wang reported memory safety problems and crashes that
 affect Firefox ESR 31 and Firefox 31.</p>
 
 <ul>
-  <li><a href="https://bugzilla.mozilla.org/buglist.cgi?bug_id=1037666,1041148,995075,&#10;1022945,1027359,1035007,1033121">
+  <li><a href="https://bugzilla.mozilla.org/buglist.cgi?bug_id=1037666,1041148,995075,1022945,1027359,1035007,1033121">
           Memory safety bugs fixed in Firefox ESR 31.1 and Firefox 32.</a> (<a href="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2014-1553" class="ex-ref">CVE-2014-1553</a>)</li>
 </ul>
 
@@ -48,7 +48,7 @@ affect Firefox ESR 31 and Firefox 31.</p>
 and crashes that affect Firefox 31.</p>
 
 <ul>
-  <li><a href="https://bugzilla.mozilla.org/buglist.cgi?bug_id=995704,990247,1004480,&#10;1016519">
+  <li><a href="https://bugzilla.mozilla.org/buglist.cgi?bug_id=995704,990247,1004480,1016519">
           Memory safety bugs fixed in Firefox 32.</a> (<a href="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2014-1554" class="ex-ref">CVE-2014-1554</a>)</li>
 </ul>
 

--- a/announce/2014/mfsa2014-74.md
+++ b/announce/2014/mfsa2014-74.md
@@ -29,7 +29,7 @@ reported memory safety problems and crashes that affect Firefox ESR 31.1 and
 Firefox 32.</p>
 
 <ul>
-  <li><a href="https://bugzilla.mozilla.org/buglist.cgi?bug_id=1072174,1061600,1064346,&#10;1011354,1072044,1061214">
+  <li><a href="https://bugzilla.mozilla.org/buglist.cgi?bug_id=1072174,1061600,1064346,1011354,1072044,1061214">
           Memory safety bugs fixed in Firefox ESR 31.2 and Firefox 33</a> (<a href="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2014-1574" class="ex-ref">CVE-2014-1574</a>)</li>
 </ul>
 
@@ -38,7 +38,7 @@ Cole, Eric Rahm , and Jeff Walden reported memory safety problems and crashes
 that affect Firefox 32.</p>
 
 <ul>
-  <li><a href="https://bugzilla.mozilla.org/buglist.cgi?bug_id=1018916,1032208,1001994,&#10;1023035,1033020,1034230,1020034">
+  <li><a href="https://bugzilla.mozilla.org/buglist.cgi?bug_id=1018916,1032208,1001994,1023035,1033020,1034230,1020034">
           Memory safety bugs fixed in Firefox 33.</a> (<a href="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2014-1575" class="ex-ref">CVE-2014-1575</a>)</li>
 </ul>
 

--- a/announce/2015/mfsa2015-30.md
+++ b/announce/2015/mfsa2015-30.md
@@ -44,7 +44,4 @@ href="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2015-0814"
 class="ex-ref">CVE-2015-0814</a>)</li>
 </ul>
 
-</ul>
-
-
 

--- a/announce/2015/mfsa2015-41.md
+++ b/announce/2015/mfsa2015-41.md
@@ -35,7 +35,7 @@ and only Firefox for Android was affected.
 (<a href="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2015-0800"
 class="ex-ref">CVE-2015-0800</a>)</li>
   <li><a href="http://blog.watchfire.com/files/androiddnsweakprng.pdf">
-        Weak randomness in Android’s DNS resolver (CVE-2012-2808)</li>
+        Weak randomness in Android’s DNS resolver (CVE-2012-2808)</a></li>
 </ul>
 
 

--- a/announce/2015/mfsa2015-44.md
+++ b/announce/2015/mfsa2015-44.md
@@ -17,7 +17,7 @@ specified in the HTTP/2 response, SSL certificate verification can be bypassed
 for the specified alternate server. As a result of this, warnings of invalid SSL
 certificates will not be displayed and an attacker could potentially impersonate
 another site through a man-in-the-middle (MTIM), replacing the original
-certificate with their own. 
+certificate with their own.</p> 
 
 <h3>References</h3>
 


### PR DESCRIPTION
#### Obvious bugs

1. I ran the advisory pool through my XML parser,  and it choked on a number of **obvious HTML bugs**. There is one commit to address all of these.
1. My link parser then stumbled across a sizable number of **malformed Bugzilla URLs**. This pull request addresses these, too. Some are particularly regular, having certain bug IDs prefixed with **&amp;#10;**, suggesting they were created by a **broken extraction or conversion script** incorrectly handling line breaks inside of URLs.
1. Lastly I found a line-broken *title* in the header of one advisory which later turned out to be the result of a **duplication of the title**, likely due to a copy&paste issue.

#### Headers

I touched two **advisory headers** to make them **consistent** with the rest:

1. One lonely advisory was using the **fix_released** field back in 2006 which is essentially **redundant** to the **announced** field. (Please note that this commit mistakenly refers to the *fixed_in* header field instead.)
1. There was a single occurrence of the **affects** header field in 2006, which was probably just a misnomer of the **vulnerable** field that was used throughout 2005.
