### PR TITLE
Please merge advisories for FxOS 2.5

### DIFF
--- a/announce/2014/mfsa2014-25.md
+++ b/announce/2014/mfsa2014-25.md
@@ -1,8 +1,8 @@
 ---
 announced: March 18, 2014
 fixed_in:
-- FirefoxOS 1.2.2
-- FirefoxOS 1.3
+- Firefox OS 1.2.2
+- Firefox OS 1.3
 impact: Moderate
 reporter: Ben Turner
 title: Firefox OS DeviceStorageFile object vulnerable to relative path escape

--- a/announce/2015/mfsa2015-102.md
+++ b/announce/2015/mfsa2015-102.md
@@ -3,6 +3,7 @@ announced: September 22, 2015
 fixed_in:
 - Firefox 41
 - SeaMonkey 2.38
+- Firefox OS 2.5
 impact: Moderate
 reporter: Spandan Veggalam
 title: Crash when using debugger with SavedStacks in JavaScript

--- a/announce/2015/mfsa2015-106.md
+++ b/announce/2015/mfsa2015-106.md
@@ -5,6 +5,7 @@ fixed_in:
 - Firefox ESR 38.3
 - Thunderbird 38.3
 - SeaMonkey 2.38
+- Firefox OS 2.5
 impact: Critical
 reporter: Anonymous
 title: Use-after-free while manipulating HTML media content

--- a/announce/2015/mfsa2015-108.md
+++ b/announce/2015/mfsa2015-108.md
@@ -3,6 +3,7 @@ announced: September 22, 2015
 fixed_in:
 - Firefox 41
 - SeaMonkey 2.38
+- Firefox OS 2.5
 impact: Moderate
 reporter: André Bargull
 title: Scripted proxies can access inner window

--- a/announce/2015/mfsa2015-110.md
+++ b/announce/2015/mfsa2015-110.md
@@ -5,6 +5,7 @@ fixed_in:
 - Firefox ESR 38.3
 - Thunderbird 38.3
 - SeaMonkey 2.38
+- Firefox OS 2.5
 impact: Moderate
 reporter: Mario Gomes
 title: Dragging and dropping images exposes final URL after redirects

--- a/announce/2015/mfsa2015-111.md
+++ b/announce/2015/mfsa2015-111.md
@@ -5,6 +5,7 @@ fixed_in:
 - Firefox ESR 38.3
 - Thunderbird 38.3
 - SeaMonkey 2.38
+- Firefox OS 2.5
 impact: High
 reporter: Ehsan Akhgari
 title: Errors in the handling of CORS preflight request headers

--- a/announce/2015/mfsa2015-112.md
+++ b/announce/2015/mfsa2015-112.md
@@ -5,6 +5,7 @@ fixed_in:
 - Firefox ESR 38.3
 - Thunderbird 38.3
 - SeaMonkey 2.38
+- Firefox OS 2.5
 impact: High
 reporter: Ronald Crane
 title: Vulnerabilities found through code inspection

--- a/announce/2015/mfsa2015-114.md
+++ b/announce/2015/mfsa2015-114.md
@@ -3,6 +3,7 @@ announced: September 22, 2015
 fixed_in:
 - Firefox 41
 - SeaMonkey 2.38
+- Firefox OS 2.5
 impact: Moderate
 reporter: Yossef Oren et al, Amit Klein
 title: Information disclosure via the High Resolution Time API

--- a/announce/2015/mfsa2015-116.md
+++ b/announce/2015/mfsa2015-116.md
@@ -4,6 +4,7 @@ fixed_in:
 - Firefox 42
 - Firefox ESR 38.4
 - Thunderbird 38.4
+- Firefox OS 2.5
 impact: Critical
 reporter: Mozilla Developers
 title: Miscellaneous memory safety hazards (rv:42.0 / rv:38.4)

--- a/announce/2015/mfsa2015-127.md
+++ b/announce/2015/mfsa2015-127.md
@@ -4,6 +4,7 @@ fixed_in:
 - Firefox 42
 - Firefox ESR 38.4
 - Thunderbird 38.4
+- Firefox OS 2.5
 impact: High
 reporter: Shinto K Anto
 title: CORS preflight is bypassed when non-standard Content-Type headers are received

--- a/announce/2015/mfsa2015-134.md
+++ b/announce/2015/mfsa2015-134.md
@@ -4,6 +4,7 @@ fixed_in:
 - Firefox 43
 - Firefox ESR 38.5
 - Thunderbird 38.5
+- Firefox OS 2.5
 impact: Critical
 reporter: Mozilla Developers
 title: Miscellaneous memory safety hazards (rv:43.0 / rv:38.5)

--- a/announce/2015/mfsa2015-138.md
+++ b/announce/2015/mfsa2015-138.md
@@ -3,6 +3,7 @@ announced: December 15, 2015
 fixed_in:
 - Firefox 43
 - Firefox ESR 38.5
+- Firefox OS 2.5
 impact: Critical
 reporter: Looben Yang
 title: Use-after-free in WebRTC when datachannel is used after being destroyed

--- a/announce/2015/mfsa2015-142.md
+++ b/announce/2015/mfsa2015-142.md
@@ -2,6 +2,7 @@
 announced: December 15, 2015
 fixed_in:
 - Firefox 43
+- Firefox OS 2.5
 impact: Low
 reporter: Stuart Larsen
 title: DOS due to malformed frames in HTTP/2

--- a/announce/2015/mfsa2015-145.md
+++ b/announce/2015/mfsa2015-145.md
@@ -4,6 +4,7 @@ fixed_in:
 - Firefox 43
 - Firefox ESR 38.5
 - Thunderbird 38.5
+- Firefox OS 2.5
 impact: High
 reporter: Ronald Crane
 title: Underflow through code inspection

--- a/announce/2015/mfsa2015-149.md
+++ b/announce/2015/mfsa2015-149.md
@@ -4,6 +4,7 @@ fixed_in:
 - Firefox 43
 - Firefox ESR 38.5
 - Thunderbird 38.5
+- Firefox OS 2.5
 impact: Critical
 reporter: Tsubasa Iinuma
 title: Cross-site reading attack through data and view-source URIs

--- a/announce/2015/mfsa2015-151.md
+++ b/announce/2015/mfsa2015-151.md
@@ -1,0 +1,25 @@
+---
+impact: Moderate
+reporter: Frederik Braun
+fixed_in: Firefox OS 2.5
+announced: December 30, 2015
+title: Lockscreen delay bypass in Firefox OS
+---
+
+<h3>Description</h3>
+
+<p><strong>Frederik Braun</strong> of Mozilla discovered a bug in the
+lockscreen state logic that allows an attacker to bypass the lockscreen
+delay. The delay was introduced to make it harder to brute-force the
+passcode lock of a Firefox OS device when an attacker has gained physical
+access. A successful attack would render that tar-pitting mechanism
+ineffective.</p>
+
+<h3>References</h3>
+
+<ul>
+  <li>
+    <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1181571">Lockscreen delay bypass in Firefox OS</a>
+   (<a href="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2015-8512" class="ex-ref">CVE-2015-8512</a>)
+  </li>
+</ul>

--- a/announce/2015/mfsa2015-152.md
+++ b/announce/2015/mfsa2015-152.md
@@ -1,0 +1,24 @@
+---
+impact: High
+reporter: Shally Li
+fixed_in: Firefox OS 2.5
+announced: December 30, 2015
+title: Lockscreen passcode bypass due to race condition
+---
+
+<h3>Description</h3>
+
+<p><strong>Shally Li</strong> was first to report a race condition
+in the lockscreen of Firefox OS that can be used to bypass the passcode
+lock of a Firefox OS device. Under certain circumstances on a locked
+device, the user will be dropped directly to the homescreen instead of
+being presented with the passcode input dialog.</p>
+
+<h3>References</h3>
+
+<ul>
+  <li>
+    <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1173284">Firefox OS Lockscreen passcode bypass due to race condition</a>
+   (<a href="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2015-8511" class="ex-ref">CVE-2015-8511</a>)
+  </li>
+</ul>

--- a/announce/2015/mfsa2015-153.md
+++ b/announce/2015/mfsa2015-153.md
@@ -1,0 +1,26 @@
+---
+impact: High
+reporter: Muneaki Nishimura
+fixed_in: Firefox OS 2.5
+announced: December 30, 2015
+title: HTML injection in homescreen app bypassing DOM sanitizer
+---
+
+<h3>Description</h3>
+
+<p>Mozilla fixed a bug in the l10n localization of the default homescreen
+app of Firefox OS reported by security researcher <strong>Muneaki
+Nishimura</strong>. Exploiting this issue requires tricking the user into
+bookmarking a specially crafted web page via the 'Add to home screen'
+functionality. As a result, an <code>iframe</code> controlled by the
+attacker would be executed with homescreen privileges, potentially
+leading to further system compromise.</p>
+
+<h3>References</h3>
+
+<ul>
+  <li>
+    <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1190038">HTML injection on homescreen app (with bypassing DOM sanitizer)</a>
+   (<a href="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2015-8510" class="ex-ref">CVE-2015-8510</a>)
+  </li>
+</ul>

--- a/announce/2015/mfsa2015-79.md
+++ b/announce/2015/mfsa2015-79.md
@@ -5,6 +5,7 @@ fixed_in:
 - Firefox ESR 38.2
 - Thunderbird 38.2
 - SeaMonkey 2.35
+- Firefox OS 2.5
 impact: Critical
 reporter: Mozilla Developers
 title: Miscellaneous memory safety hazards (rv:40.0 / rv:38.2)

--- a/announce/2015/mfsa2015-80.md
+++ b/announce/2015/mfsa2015-80.md
@@ -4,6 +4,7 @@ fixed_in:
 - Firefox 40
 - Firefox ESR 38.2
 - SeaMonkey 2.35
+- Firefox OS 2.5
 impact: High
 reporter: Aki Helin
 title: Out-of-bounds read with malformed MP3 file

--- a/announce/2015/mfsa2015-81.md
+++ b/announce/2015/mfsa2015-81.md
@@ -3,6 +3,7 @@ announced: August 11, 2015
 fixed_in:
 - Firefox 40
 - SeaMonkey 2.38
+- Firefox OS 2.5
 impact: Critical
 reporter: SkyLined
 title: Use-after-free in MediaStream playback

--- a/announce/2015/mfsa2015-85.md
+++ b/announce/2015/mfsa2015-85.md
@@ -5,6 +5,7 @@ fixed_in:
 - Firefox ESR 38.2
 - Thunderbird 38.2
 - SeaMonkey 2.35
+- Firefox OS 2.5
 impact: High
 reporter: Holger Fuhrmannek
 title: Out-of-bounds write with Updater and malicious MAR file

--- a/announce/2015/mfsa2015-89.md
+++ b/announce/2015/mfsa2015-89.md
@@ -4,6 +4,7 @@ fixed_in:
 - Firefox 40
 - Firefox ESR 38.2
 - SeaMonkey 2.35
+- Firefox OS 2.5
 impact: Critical
 reporter: Abhishek Arya
 title: Buffer overflows on Libvpx when decoding WebM video

--- a/announce/2015/mfsa2015-90.md
+++ b/announce/2015/mfsa2015-90.md
@@ -6,6 +6,7 @@ fixed_in:
 - Thunderbird 38.2
 - Firefox OS 2.2
 - SeaMonkey 2.35
+- Firefox OS 2.5
 impact: High
 reporter: Ronald Crane
 title: Vulnerabilities found through code inspection

--- a/announce/2015/mfsa2015-92.md
+++ b/announce/2015/mfsa2015-92.md
@@ -4,6 +4,7 @@ fixed_in:
 - Firefox 40
 - Firefox ESR 38.2
 - SeaMonkey 2.35
+- Firefox OS 2.5
 impact: High
 reporter: Looben Yang
 title: Use-after-free in XMLHttpRequest with shared workers

--- a/announce/2015/mfsa2015-96.md
+++ b/announce/2015/mfsa2015-96.md
@@ -5,6 +5,7 @@ fixed_in:
 - Firefox ESR 38.3
 - SeaMonkey 2.38
 - Thunderbird 38.3
+- Firefox OS 2.5
 impact: Critical
 reporter: Mozilla Developers
 title: Miscellaneous memory safety hazards (rv:41.0 / rv:38.3)


### PR DESCRIPTION
This PR not only includes the advisory pool changes for the 2.5 release, but also a bugfix for mfsa2014-25 which used "FirefoxOS" instead of the regular, white-spaced "Firefox OS" in its fixed_in field, making it appear in a different listing than the other FxOS-related advisories.