### PR TITLE
Wrap title in quotes due to unwrapped colon signifying map

### DIFF
--- a/announce/2017/mfsa2017-30.yml
+++ b/announce/2017/mfsa2017-30.yml
@@ -38,7 +38,7 @@ advisories:
     bugs:
       - url: 1411699
   CVE-2017-7829:
-    title: Mailsploit part 1: From address with encoded null character is cut off in message header display
+    title: "Mailsploit part 1: From address with encoded null character is cut off in message header display"
     impact: low
     reporter: Sabri Haddouche
     description: |


### PR DESCRIPTION
Fix for the following error from the clock proc logs:
```
ERROR parsing /tmp/mofo_security_advisories/announce/2017/mfsa2017-30.yml: mapping values are not allowed here
  in "/tmp/mofo_security_advisories/announce/2017/mfsa2017-30.yml", line 41, column 29
[2017-12-23 17:40:34.114568] Clock job update_security_advisories@bedrock-prod: CRASHED: Command 'python /app/manage.py update_security_advisories' returned non-zero exit status 1
```