### PR TITLE
check_advisories: make the "bugs" field mandatory

### DIFF
--- a/check_advisories.py
+++ b/check_advisories.py
@@ -43,6 +43,7 @@ REQUIRED_YAML_ADVISORY_FIELDS = (
     'impact',
     'reporter',
     'description',
+    'bugs',
 )
 
 


### PR DESCRIPTION
bedrock breaks when it's not present[1], and this would have caught the
mistake fixed by commit 858ccec2c "fix yaml format error"

[1] https://github.com/mozilla/bedrock/blob/747ee3e649afc1317e1bb6f0909696d3c65c33ca/bedrock/security/management/commands/update_security_advisories.py#L147