### PR TITLE
check_advisories: check product names and version numbers

### DIFF
--- a/check_advisories.py
+++ b/check_advisories.py
@@ -44,6 +44,21 @@ REQUIRED_YAML_ADVISORY_FIELDS = (
     'reporter',
     'description',
 )
+PRODUCTS = (
+    'Firefox',
+    'Firefox ESR',
+    'Firefox Mobile',
+    'Firefox OS',
+    'Mozilla Suite',
+    'Netscape Portable Runtime',
+    'NSS',
+    'OpenH264',
+    'SeaMonkey',
+    'Seamonkey',
+    'Thunderbird',
+    'Thunderbird ESR',
+)
+VERSION_RE = re.compile(r'^[0-9]+(\.[0-9]+)*$')
 
 
 def mfsa_id_from_filename(filename):
@@ -147,6 +162,15 @@ def check_file(file_name):
     for field in required_fields:
         if field not in data:
             return 'The {0} field is required in the file metadata.'.format(field)
+
+    for product in data['fixed_in']:
+        # split the product and version number
+        p, v = product.rsplit(None, 1)
+        if p not in PRODUCTS:
+            return '{0} is not a known product name'.format(p)
+        if not VERSION_RE.search(v):
+            return 'Failed to parse "{}" as a version number'.format(v)
+
 
     if 'announced' in data:
         try:


### PR DESCRIPTION
Add a whitelist of product names and a check for plausible version
numbers.

This should help catch issues such as the one reported at
https://mail.mozilla.org/pipermail/enterprise/2020-March/002185.html and
fixed in commit deb0db18 "Fix yaml for Firefox 68.5 and 68.6 advisories
so they show up in the index"

I'm not sure about the product list, maybe that isn't necessary...

cc @tomrittervg 