### PR TITLE
Add more missing HOF entries back to the list.

### DIFF
--- a/bug-bounty-hof/client.yml
+++ b/bug-bounty-hof/client.yml
@@ -379,6 +379,8 @@ names:
   date: 2018-03-27
 - name: Nils
   date: 2018-03-27
+- name: Tadj Youssouf
+  date: 2018-03-26
 - name: Ronald Crane
   date: 2018-03-26
   url: https://www.zippenhop.com/
@@ -621,7 +623,7 @@ names:
   date: 2017-02-13
   twitter: "@qab"
   url: https://twitter.com/@qab
-- name: Anonymous
+- name: KSoze
   date: 2017-02-13
 - name: André Bargull
   date: 2017-01-30
@@ -665,7 +667,7 @@ names:
   url: https://twitter.com/@geeknik
 - name: Nils
   date: 2016-11-07
-- name: Anonymous
+- name: KSoze
   date: 2016-11-07
 - name: Raphael Shaniyazov
   date: 2016-10-10
@@ -909,6 +911,8 @@ names:
   date: 2015-09-14
   twitter: "@attekett"
   url: https://twitter.com/@attekett
+- name: KSoze
+  date: 2015-09-12
 - name: Muneaki Nishimura (a.k.a. nishimunea)
   date: 2015-09-04
 - name: Armin Razmjou
@@ -947,8 +951,6 @@ names:
   date: 2015-07-20
   twitter: "@revskills"
   url: https://twitter.com/@revskills
-- name: Cody Crews
-  date: 2015-07-20
 - name: SkyLined
   date: 2015-07-20
   url: https://skylined.nl
@@ -1073,8 +1075,6 @@ names:
   date: 2014-12-12
 - name: Muneaki Nishimura (a.k.a. nishimunea)
   date: 2014-12-08
-- name: Cody Crews
-  date: 2014-12-08
 - name: Atte Kettunen
   date: 2014-11-20
   twitter: "@attekett"
@@ -1096,6 +1096,8 @@ names:
   date: 2014-10-01
 - name: Abhishek Arya
   date: 2014-09-29
+- name: KSoze
+  date: 2014-09-15
 - name: Antoine Delignat-Lavaud
   date: 2014-09-08
   url: https://antoine.delignat-lavaud.fr
@@ -1130,8 +1132,8 @@ names:
   date: 2014-06-04
 - name: Looben Yang
   date: 2014-06-02
-- name: Cody Crews
-  date: 2014-06-02
+- name: Jann Horn
+  date: 2014-05-29
 - name: Nicolas Francois
   date: 2014-05-19
 - name: Nils
@@ -1142,6 +1144,8 @@ names:
   date: 2014-05-12
   twitter: "@attekett"
   url: https://twitter.com/@attekett
+- name: KSoze
+  date: 2014-04-29
 - name: Holger Fuhrmannek
   date: 2014-04-28
 - name: Mariusz Mlynski
@@ -1192,12 +1196,14 @@ names:
   date: 2013-11-06
 - name: sachin shinde
   date: 2013-11-04
-- name: Cody Crews
-  date: 2013-11-04
 - name: Masato Kinugawa
   date: 2013-10-16
+- name: "Gabor Molnar"
+  date: 2013-10-01
 - name: "Jesse Schwartzentruber"
   date: 2013-10-01
+- name: KSoze
+  date: 2013-09-30
 - name: Abhishek Arya
   date: 2013-09-30
 - name: lifeasageek
@@ -1213,6 +1219,8 @@ names:
   url: https://twitter.com/@attekett
 - name: Scott Bell
   date: 2013-09-09
+- name: KSoze
+  date: 2013-08-01
 - name: Jordi Chancel
   date: 2013-07-29
 - name: Context Information Security
@@ -1224,7 +1232,7 @@ names:
   date: 2013-07-15
   twitter: "@sebbity"
   url: https://twitter.com/@sebbity
-- name: Cody Crews
+- name: "Ash"
   date: 2013-07-01
 - name: Holger Fuhrmannek
   date: 2013-07-01
@@ -1255,20 +1263,24 @@ names:
   url: https://twitter.com/@sebbity
 - name: Nils
   date: 2013-04-14
+- name: "Ash"
+  date: 2013-04-01
 - name: Robert Kugler
   date: 2013-04-01
 - name: Abhishek Arya
   date: 2013-03-25
-- name: Cody Crews
-  date: 2013-03-25
 - name: Frédéric Hoguin
   date: 2013-03-11
+- name: Nicolas
+  date: 2013-03-07
 - name: Nils
   date: 2013-03-04
 - name: Holger Fuhrmannek
   date: 2013-03-04
 - name: Fourteenforty Research Institute Japan
   date: 2013-03-04
+- name: KSoze
+  date: 2013-02-04
 - name: Scott Bell
   date: 2013-02-04
 - name: Mariusz Mlynski
@@ -1285,6 +1297,8 @@ names:
   date: 2013-01-07
   twitter: "@attekett"
   url: https://twitter.com/@attekett
+- name: "Ash"
+  date: 2013-01-01
 - name: Atte Kettunen
   date: 2012-12-17
   twitter: "@attekett"
@@ -1299,6 +1313,10 @@ names:
   date: 2012-12-10
 - name: Masato Kinugawa
   date: 2012-12-03
+- name: Atte Kettunen
+  date: 2012-11-29
+  twitter: "@attekett"
+  url: https://twitter.com/@attekett
 - name: Michal Zalewski
   date: 2012-11-19
   url: http://lcamtuf.coredump.cx/
@@ -1343,6 +1361,8 @@ names:
 - name: "Sevenspade"
   date: 2012-07-01
 - name: "Colby Russell"
+  date: 2012-07-01
+- name: "Frederik Braun"
   date: 2012-07-01
 - name: Soroush Dalili
   date: 2012-06-29
@@ -1522,6 +1542,10 @@ names:
 - name: Michal Zalewski
   date: 2010-10-11
   url: http://lcamtuf.coredump.cx/
+- name: "Aki Helin"
+  date: 2010-10-01
+- name: "Martin Barbella"
+  date: 2010-10-01
 - name: Ilja van Sprundel of IOActive
   date: 2010-07-24
 - name: "Gregory Fleischer"
@@ -1530,3 +1554,13 @@ names:
   date: 2010-07-01
 - name: Jordi Chancel
   date: 2010-05-11
+- name: "David Lin-Shung Huang"
+  date: 2010-07-01
+- name: "Gregory Fleischer"
+  date: 2010-07-01
+- name: "Marc Schoenefeld"
+  date: 2010-07-01
+- name: "Sergey Glazunov"
+  date: 2010-07-01
+- name: "Siddharth Agarwal"
+  date: 2010-07-01

--- a/update_hof.py
+++ b/update_hof.py
@@ -435,7 +435,7 @@ def main():
         foundAttachment = None
         for attachment in attachments:
             if attachment['file_name'] == 'bugbounty.data' and attachment['is_private'] == 1:
-                if foundAttachment:
+                if foundAttachment and bugid not in ["913805"]:
                     raise Exception("Two bug bounty attachments were found for " + bugid)
                 foundAttachment = attachment
 
@@ -444,10 +444,10 @@ def main():
                 attachment = foundAttachment
 
                 data = {}
-                attachment_breakout = attachment['description'].split(',')
-                data["email"] = attachment_breakout[0]
+                attachment_breakout = attachment['description'].split(',').strip()
+                data["email"] = attachment_breakout[0].strip()
                 data["email_hmac"] = hmac_email(hmackey, attachment_breakout[0])
-                data["date_raw"] = attachment_breakout[4] or attachment_breakout[3] or attachment_breakout[2]
+                data["date_raw"] = attachment_breakout[4] or attachment_breakout[3].strip() or attachment_breakout[2].strip()
                 data["date"] = datetime.strptime(data["date_raw"], '%Y-%m-%d')
                 
                 debuglog.write("bounty+," + data["date_raw"] + "," + data["email"] + "," + data["email_hmac"] + ",")
@@ -461,10 +461,13 @@ def main():
                     # print("Generating Data For Bug %s - %s" % (bugid, data["email"]))
                     numFields = len(attachment_breakout)
 
-                    if not bool(attachment_breakout[5]) or "no" == attachment_breakout[5].lower():
+                    if not bool(attachment_breakout[5]):
+                        debuglog.write("Publish was blank,")
+                    elif "no" == attachment_breakout[5].lower() or "false" == attachment_breakout[5].lower():
                         debuglog.write("Do Not Publish\n")
-                        # Do not publish
                         continue
+                    else:
+                        debuglog.write("publish,")
 
                     data["name"] = ""
                     if numFields > 6 and attachment_breakout[6]:


### PR DESCRIPTION
Some of these were missing due to a mistake about the publish field,
others to a suspected file overlap date cutoff-related I-made-a-mistake
problem.