### PR TITLE
Remove linebreak in URL to referenced Android commit

### DIFF
--- a/announce/2015/mfsa2015-147.md
+++ b/announce/2015/mfsa2015-147.md
@@ -28,8 +28,7 @@ Thunderbird product, but is potentially a risk in browser or browser-like contex
 (<a href="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2015-7222"
 class="ex-ref">CVE-2015-7222</a>)</li>
    <li><a
-href="https://android.googlesource.com/platform/frameworks/av/+/
-c87faed60483afb2466e03892bda80b72e5822c7%5E!/#F0">Fix integer underflow in covr MPEG4
+href="https://android.googlesource.com/platform/frameworks/av/+/c87faed60483afb2466e03892bda80b72e5822c7%5E!/#F0">Fix integer underflow in covr MPEG4
 processing</a></li>
 </ul>
 


### PR DESCRIPTION
This URL was spotted as broken by a tool I'm creating for checking www.mozilla.org. I've removed the linebreak and confirmed via the Preview tab that it still works.

If this could be merged into master, that would be appreciated.

Equally, if this file is somehow autogenerated upstream, making any fix likely to be overwritten, do let me know. Thanks!