### PR TITLE
Fix incorrect parenthesis in href - link was 404ing

### DIFF
--- a/announce/2013/mfsa2013-48.md
+++ b/announce/2013/mfsa2013-48.md
@@ -28,7 +28,7 @@ fixed before general release.</p>
   <li><a href="https://bugzilla.mozilla.org/show_bug.cgi?id=818454">
        Out of Bounds Read in SelectionIterator::GetNextSegment</a> (<a href="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2013-1676" class="ex-ref">CVE-2013-1676</a>)</li>
   <li><a href="https://bugzilla.mozilla.org/show_bug.cgi?id=826163">
-      Out-of-bound read in gfxSkipCharsIterator::SetOffsets</a> (<a href="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2013-1677)" class="ex-ref">CVE-2013-1677)</a>)</li>
+      Out-of-bound read in gfxSkipCharsIterator::SetOffsets</a> (<a href="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2013-1677" class="ex-ref">CVE-2013-1677</a>)</li>
   <li><a href="https://bugzilla.mozilla.org/show_bug.cgi?id=839745">
       Invalid write in _cairo_xlib_surface_add_glyph</a> (<a href="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2013-1678" class="ex-ref">CVE-2013-1678</a>)</li>
   <li><a href="https://bugzilla.mozilla.org/show_bug.cgi?id=848237">


### PR DESCRIPTION
Spotted with a linkchecker tool being developed for mozilla.org - fixing this upstream means we don't need to add a special case to ignore it in the tool