### PR TITLE
Remove unnecessary closing parenthesis in URL href

### DIFF
--- a/announce/2013/mfsa2013-74.md
+++ b/announce/2013/mfsa2013-74.md
@@ -27,7 +27,7 @@ run with those administrator privileges.</p>
 <ul>
   <li><a href="https://bugzilla.mozilla.org/show_bug.cgi?id=883165">
        Medium integrity DLL Hijacking - Firefox Full installer and Stub
-installer</a> (<a href="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2013-1715)" class="ex-ref">CVE-2013-1715)</a>)</li>
+installer</a> (<a href="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2013-1715" class="ex-ref">CVE-2013-1715</a>)</li>
   <li><a href="https://bugzilla.mozilla.org/show_bug.cgi?id=811557">
        DLL Hijacking - Firefox Stub installer</a></li>
  <li><a href="https://bugzilla.mozilla.org/show_bug.cgi?id=883322">


### PR DESCRIPTION
Spotted with the WIP linkchecker tool - fixing this upstream means we need one less special rule in the checker tool, thanks!