### PR TITLE
move mention from client to web HoF

### DIFF
--- a/bug-bounty-hof/client.yml
+++ b/bug-bounty-hof/client.yml
@@ -1,8 +1,4 @@
 names:
-- name: Khalid Matar Alharthi
-  date: 2021-03-31
-  twitter: "@Khalid501r"
-  url: https://twitter.com/Khalid501r
 - name: Alison Huffman
   date: 2022-03-22
 - name: Sohom Datta

--- a/bug-bounty-hof/web.yml
+++ b/bug-bounty-hof/web.yml
@@ -1,4 +1,8 @@
 names:
+- name: Khalid Matar Alharthi
+  date: 2021-03-31
+  twitter: "@Khalid501r"
+  url: https://twitter.com/Khalid501r
 - name: Griffin Francis
   date: 2022-03-28
 - name: zy9ard3


### PR DESCRIPTION
Hello @tomrittervg can you please check the PR? the missing mention was added to the client not the web HoF, thanks.

for reference, this is the bug for this mention https://bugzilla.mozilla.org/show_bug.cgi?id=1701644