### PR TITLE
Fix bad formatting of "Products" and "Fixed In" sections for latest advisory

### DIFF
--- a/announce/2023/mfsa2023-40.yml
+++ b/announce/2023/mfsa2023-40.yml
@@ -2,7 +2,11 @@
 announced: September 12, 2023
 impact: critical
 fixed_in:
-  - Firefox 117.0.1, Firefox ESR 115.2.1, Firefox ESR 102.15.1, Thunderbird 102.15.1, and Thunderbird 115.2.2
+  - Firefox 117.0.1
+  - Firefox ESR 115.2.1
+  - Firefox ESR 102.15.1
+  - Thunderbird 102.15.1
+  - Thunderbird 115.2.2
 
 title: Security Vulnerability fixed in Firefox 117.0.1, Firefox ESR 115.2.1, Firefox ESR 102.15.1, Thunderbird 102.15.1, and Thunderbird 115.2.2
 advisories:

--- a/foundation_security_advisories/check_advisories.py
+++ b/foundation_security_advisories/check_advisories.py
@@ -108,6 +108,8 @@ def check_file(file_name):
     for f in data['fixed_in']:
         if "ESR" in f and "ESR " not in f:
             return "When ESR is specified, it must be of the form 'Firefox ESR XX', not 'Firefox ESRXX' (Found '" + f + "')"
+        if "," in f:
+            return f"When 'fixed_in' contains multiple products, they should be enumerated with YAML and not with commas in a string (Found '{f}')"
 
     if 'announced' in data:
         try:


### PR DESCRIPTION
The latest advisory is currently being formatted weirdly because the products are all listed in one string with commas.

![Screenshot_20230913_124733](https://github.com/mozilla/foundation-security-advisories/assets/48161361/2d2bac11-9dd6-4eb1-a78c-cd724543f882)

- So this PR fixes that for MFSA-2023-40
- And adds a check to `check_advisories` so it doesn't happen again