### PR TITLE
Separate Push and Pull Request Workflows

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,19 @@
+name: Pull Request
+
+on: pull_request
+
+jobs:
+  check:
+    name: Check Advisories
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v3
+      - name: Set up Python 3
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+      - name: Install Python dependencies
+        run: pip install ./
+      - name: Run Advisories Checks
+        run: check_advisories --all

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,8 +1,6 @@
 name: Push
 
 on:
-  # Triggers the workflow on push events only for the default branch
-  pull_request:
   push:
     branches:
       - master


### PR DESCRIPTION
To make sure that the publish workflow isn't run on pull requests.