### PR TITLE
Fix Firefox version in ESR advisory

### DIFF
--- a/announce/2023/mfsa2023-50.yml
+++ b/announce/2023/mfsa2023-50.yml
@@ -2,7 +2,7 @@
 announced: November 21, 2023
 impact: high
 fixed_in:
-- Firefox 115.5
+- Firefox ESR 115.5
 title: Security Vulnerabilities fixed in Firefox ESR 115.5
 advisories:
   CVE-2023-6204:


### PR DESCRIPTION
This is to specifically reference the 115.5 ESR version as "fixed in" not implicitly the 115.5 Release version

Please see https://bugzilla.mozilla.org/show_bug.cgi?id=1866012 for the original report