### PR TITLE
Improve formatting checks arround advisory titles and descriptions 

### DIFF
--- a/announce/2016/mfsa2016-85.yml
+++ b/announce/2016/mfsa2016-85.yml
@@ -6,7 +6,7 @@ fixed_in:
 title: Security vulnerabilities fixed in Firefox 49
 advisories:
   CVE-2016-2827:
-    title: Out-of-bounds read in mozilla::net::IsValidReferrerPolicy
+    title: "Out-of-bounds read in mozilla::net::IsValidReferrerPolicy"
     impact: low
     reporter: Atte Kettunen
     description: |
@@ -15,7 +15,7 @@ advisories:
       - url: 1289085
         desc: Bug 1289085
   CVE-2016-5270:
-    title: Heap-buffer-overflow in nsCaseTransformTextRunFactory::TransformString
+    title: "Heap-buffer-overflow in nsCaseTransformTextRunFactory::TransformString"
     impact: high
     reporter: Atte Kettunen
     description: An out-of-bounds write of a boolean value during text conversion with some unicode characters
@@ -23,7 +23,7 @@ advisories:
       - url: 1291016
         desc: Bug 1291016
   CVE-2016-5271:
-    title: Out-of-bounds read in PropertyProvider::GetSpacingInternal
+    title: "Out-of-bounds read in PropertyProvider::GetSpacingInternal"
     impact: low
     reporter: Abhishek Arya
     description: |
@@ -41,7 +41,7 @@ advisories:
       - url: 129793
         desc: Bug 129793
   CVE-2016-5273:
-    title: crash in mozilla::a11y::HyperTextAccessible::GetChildOffset
+    title: "crash in mozilla::a11y::HyperTextAccessible::GetChildOffset"
     impact: high
     reporter: Nils
     description: A potentially exploitable crash in accessibility.
@@ -49,7 +49,7 @@ advisories:
       - url: 1280387
         desc: Bug 1280387
   CVE-2016-5276:
-    title: Heap-use-after-free in mozilla::a11y::DocAccessible::ProcessInvalidationList
+    title: "Heap-use-after-free in mozilla::a11y::DocAccessible::ProcessInvalidationList"
     impact: high
     reporter: Nils
     description: |
@@ -58,7 +58,7 @@ advisories:
       - url: 1287721
         desc: Bug 1287721
   CVE-2016-5274:
-    title: use-after-free in nsFrameManager::CaptureFrameState
+    title: "use-after-free in nsFrameManager::CaptureFrameState"
     impact: high
     reporter: Nils
     description: A use-after-free issue in web animations during restyling.
@@ -66,7 +66,7 @@ advisories:
       - url: 1282076
         desc: Bug 1282076
   CVE-2016-5277:
-    title: Heap-use-after-free in nsRefreshDriver::Tick
+    title: "Heap-use-after-free in nsRefreshDriver::Tick"
     impact: high
     reporter: Nils
     description: A use-after-free vulnerability with web animations when destroying a timeline.
@@ -74,7 +74,7 @@ advisories:
       - url: 1291665
         desc: Bug 1291665
   CVE-2016-5275:
-    title: Buffer overflow in mozilla::gfx::FilterSupport::ComputeSourceNeededRegions 
+    title: "Buffer overflow in mozilla::gfx::FilterSupport::ComputeSourceNeededRegions "
     impact: critical
     reporter: Nils
     description: A buffer overflow when working with empty filters during canvas rendering.
@@ -82,7 +82,7 @@ advisories:
       - url: 1287316
         desc: Bug 1287316
   CVE-2016-5278:
-    title: Heap-buffer-overflow in nsBMPEncoder::AddImageFrame
+    title: "Heap-buffer-overflow in nsBMPEncoder::AddImageFrame"
     impact: critical
     reporter: Nils
     description: A potentially exploitable crash caused by a buffer overflow while encoding image frames to images.
@@ -98,7 +98,7 @@ advisories:
       - url: 1249522
         desc: Bug 1249522
   CVE-2016-5280:
-    title: Use-after-free in mozilla::nsTextNodeDirectionalityMap::RemoveElementFromMap
+    title: "Use-after-free in mozilla::nsTextNodeDirectionalityMap::RemoveElementFromMap"
     impact: high
     reporter: Mei Wang
     description: Use-after-free vulnerability when changing text direction.

--- a/announce/2016/mfsa2016-86.yml
+++ b/announce/2016/mfsa2016-86.yml
@@ -6,7 +6,7 @@ fixed_in:
 title: Security vulnerabilities fixed in Firefox ESR 45.4
 advisories:
   CVE-2016-5270:
-    title: Heap-buffer-overflow in nsCaseTransformTextRunFactory::TransformString
+    title: "Heap-buffer-overflow in nsCaseTransformTextRunFactory::TransformString"
     impact: high
     reporter: Atte Kettunen
     description: An out-of-bounds write of a boolean value during text conversion with some unicode characters
@@ -23,7 +23,7 @@ advisories:
       - url: 129793
         desc: Bug 129793
   CVE-2016-5276:
-    title: Heap-use-after-free in mozilla::a11y::DocAccessible::ProcessInvalidationList
+    title: "Heap-use-after-free in mozilla::a11y::DocAccessible::ProcessInvalidationList"
     impact: high
     reporter: Nils
     description: |
@@ -32,7 +32,7 @@ advisories:
       - url: 1287721
         desc: Bug 1287721
   CVE-2016-5274:
-    title: use-after-free in nsFrameManager::CaptureFrameState
+    title: "use-after-free in nsFrameManager::CaptureFrameState"
     impact: high
     reporter: Nils
     description: A use-after-free issue in web animations during restyling.
@@ -40,7 +40,7 @@ advisories:
       - url: 1282076
         desc: Bug 1282076
   CVE-2016-5277:
-    title: Heap-use-after-free in nsRefreshDriver::Tick
+    title: "Heap-use-after-free in nsRefreshDriver::Tick"
     impact: high
     reporter: Nils
     description: A use-after-free vulnerability with web animations when destroying a timeline.
@@ -48,7 +48,7 @@ advisories:
       - url: 1291665
         desc: Bug 1291665
   CVE-2016-5278:
-    title: Heap-buffer-overflow in nsBMPEncoder::AddImageFrame
+    title: "Heap-buffer-overflow in nsBMPEncoder::AddImageFrame"
     impact: critical
     reporter: Nils
     description: A potentially exploitable crash caused by a buffer overflow while encoding image frames to images.
@@ -56,7 +56,7 @@ advisories:
       - url: 1294677
         desc: Bug 1294677
   CVE-2016-5280:
-    title: Use-after-free in mozilla::nsTextNodeDirectionalityMap::RemoveElementFromMap
+    title: "Use-after-free in mozilla::nsTextNodeDirectionalityMap::RemoveElementFromMap"
     impact: high
     reporter: Mei Wang
     description: Use-after-free vulnerability when changing text direction.

--- a/announce/2016/mfsa2016-87.yml
+++ b/announce/2016/mfsa2016-87.yml
@@ -6,7 +6,7 @@ fixed_in:
 title: Security vulnerabilities fixed in Firefox 49.0.2
 advisories:
   CVE-2016-5287:
-    title: Crash in nsTArray_base&lt;T&gt;::SwapArrayElements
+    title: "Crash in nsTArray_base&lt;T&gt;::SwapArrayElements"
     impact: high
     reporter: Philipp
     description: A potentially exploitable use-after-free crash during actor destruction with service workers. This issue does not affect releases earlier than Firefox 49.

--- a/announce/2016/mfsa2016-88.yml
+++ b/announce/2016/mfsa2016-88.yml
@@ -8,7 +8,7 @@ description: |
     *In general, these flaws cannot be exploited through email in the Thunderbird product because scripting is disabled when reading mail, but are potentially risks in browser or browser-like contexts.*
 advisories:
   CVE-2016-5270:
-    title: Heap-buffer-overflow in nsCaseTransformTextRunFactory::TransformString
+    title: "Heap-buffer-overflow in nsCaseTransformTextRunFactory::TransformString"
     impact: high
     reporter: Atte Kettunen
     description: An out-of-bounds write of a boolean value during text conversion with some unicode characters.
@@ -24,7 +24,7 @@ advisories:
       - url: 1297934
         desc: 1297934
   CVE-2016-5276:
-    title: Heap-use-after-free in mozilla::a11y::DocAccessible::ProcessInvalidationList
+    title: "Heap-use-after-free in mozilla::a11y::DocAccessible::ProcessInvalidationList"
     impact: high
     reporter: Nils
     description: A use-after-free vulnerability triggered by setting a <code>aria-owns</code> attribute
@@ -32,7 +32,7 @@ advisories:
       - url: 1287721
         desc: 1287721
   CVE-2016-5274:
-    title: use-after-free in nsFrameManager::CaptureFrameState
+    title: "use-after-free in nsFrameManager::CaptureFrameState"
     impact: high
     reporter: Nils
     description: A use-after-free issue in web animations during restyling.
@@ -40,7 +40,7 @@ advisories:
       - url: 1282076
         desc: 1282076      
   CVE-2016-5277:
-    title: Heap-use-after-free in nsRefreshDriver::Tick
+    title: "Heap-use-after-free in nsRefreshDriver::Tick"
     impact: high
     reporter: Nils
     description: A use-after-free vulnerability with web animations when destroying a timeline
@@ -48,7 +48,7 @@ advisories:
       - url: 1291665
         desc: 1291665
   CVE-2016-5278:
-    title: Heap-buffer-overflow in nsBMPEncoder::AddImageFrame
+    title: "Heap-buffer-overflow in nsBMPEncoder::AddImageFrame"
     impact: critical
     reporter: Nils
     description: A potentially exploitable crash caused by a buffer overflow while encoding image frames to images
@@ -56,7 +56,7 @@ advisories:
       - url: 1294677
         desc: 1294677
   CVE-2016-5280:
-    title: Use-after-free in mozilla::nsTextNodeDirectionalityMap::RemoveElementFromMap
+    title: "Use-after-free in mozilla::nsTextNodeDirectionalityMap::RemoveElementFromMap"
     impact: high
     reporter: Mei Wang
     description: Use-after-free vulnerability when changing text direction

--- a/announce/2016/mfsa2016-89.yml
+++ b/announce/2016/mfsa2016-89.yml
@@ -73,7 +73,7 @@ advisories:
       - url: 1299686
         desc: 
   CVE-2016-9067:
-    title: heap-use-after-free in nsINode::ReplaceOrInsertBefore
+    title: "heap-use-after-free in nsINode::ReplaceOrInsertBefore"
     impact: high
     reporter: Nils
     description: Two use-after-free errors during DOM operations resulting in potentially exploitable crashes.

--- a/announce/2017/mfsa2017-10.yml
+++ b/announce/2017/mfsa2017-10.yml
@@ -235,7 +235,7 @@ advisories:
     bugs:
       - url: 1340127
   CVE-2017-5450:
-    title:  "Addressbar spoofing using javascript: URI on Firefox for Android"
+    title: "Addressbar spoofing using javascript: URI on Firefox for Android"
     impact: moderate
     reporter: Haosheng Wang
     description: |

--- a/announce/2017/mfsa2017-18.yml
+++ b/announce/2017/mfsa2017-18.yml
@@ -182,7 +182,7 @@ advisories:
     bugs:
       - url: 1360842
   CVE-2017-7788:
-    title: Sandboxed about:srcdoc iframes do not inherit CSP directives
+    title: "Sandboxed about:srcdoc iframes do not inherit CSP directives"
     impact: low
     reporter: Muneaki Nishimura
     description: |

--- a/announce/2017/mfsa2017-30.yml
+++ b/announce/2017/mfsa2017-30.yml
@@ -14,7 +14,7 @@ advisories:
     bugs:
       - url: 1402372
   CVE-2017-7846:
-    title: JavaScript Execution via RSS in mailbox:// origin
+    title: "JavaScript Execution via RSS in mailbox:// origin"
     impact: high
     reporter: cure53
     description: |

--- a/announce/2018/mfsa2018-11.yml
+++ b/announce/2018/mfsa2018-11.yml
@@ -175,7 +175,7 @@ advisories:
     bugs:
       - url: 1451452
   CVE-2018-5180:
-    title: heap-use-after-free in mozilla::WebGLContext::DrawElementsInstanced
+    title: "heap-use-after-free in mozilla::WebGLContext::DrawElementsInstanced"
     impact: low
     reporter: Nils
     description: |

--- a/announce/2021/mfsa2021-03.yml
+++ b/announce/2021/mfsa2021-03.yml
@@ -78,7 +78,7 @@ advisories:
     bugs:
       - url: 1677940
   CVE-2021-23962:
-    title: 'Use-after-poison in <code>nsTreeBodyFrame::RowCountChanged</code>'
+    title: 'Use-after-poison in "nsTreeBodyFrame::RowCountChanged"'
     impact: low
     reporter: Chiaki ISHIKAWA
     description: |

--- a/announce/2021/mfsa2021-07.yml
+++ b/announce/2021/mfsa2021-07.yml
@@ -70,7 +70,7 @@ advisories:
     bugs:
       - url: 1683536
   CVE-2021-23975:
-    title: about:memory Measure function caused an incorrect pointer operation
+    title: "about:memory Measure function caused an incorrect pointer operation"
     impact: low
     reporter: Brian Carpenter of Geeknik Labs & Farm
     description: |

--- a/announce/2021/mfsa2021-23.yml
+++ b/announce/2021/mfsa2021-23.yml
@@ -24,11 +24,11 @@ advisories:
     bugs:
       - url: 1675965
   CVE-2021-29961:
-    title: Firefox UI spoof using `<select>` elements and CSS scaling
+    title: Firefox UI spoof using "<select>" elements and CSS scaling
     impact: moderate
     reporter: Irvan Kurniawan
     description: |
-      When styling and rendering an oversized `<select>` element, Firefox did not apply correct clipping which allowed an attacker to paint over the user interface.
+      When styling and rendering an oversized `&lt;select>` element, Firefox did not apply correct clipping which allowed an attacker to paint over the user interface.
     bugs:
       - url: 1700235
   CVE-2021-29963:
@@ -41,7 +41,7 @@ advisories:
     bugs:
       - url: 1705068
   CVE-2021-29964:
-    title: Out of bounds-read when parsing a `WM_COPYDATA` message
+    title: Out of bounds-read when parsing a "WM_COPYDATA" message
     impact: moderate
     reporter: Ronald Crane
     description: |

--- a/announce/2021/mfsa2021-24.yml
+++ b/announce/2021/mfsa2021-24.yml
@@ -6,7 +6,7 @@ fixed_in:
 title: Security Vulnerabilities fixed in Firefox ESR 78.11
 advisories:
   CVE-2021-29964:
-    title: Out of bounds-read when parsing a `WM_COPYDATA` message
+    title: Out of bounds-read when parsing a "WM_COPYDATA" message
     impact: moderate
     reporter: Ronald Crane
     description: |

--- a/announce/2021/mfsa2021-26.yml
+++ b/announce/2021/mfsa2021-26.yml
@@ -6,7 +6,7 @@ fixed_in:
 title: Security Vulnerabilities fixed in Thunderbird 78.11
 advisories:
   CVE-2021-29964:
-    title: Out of bounds-read when parsing a `WM_COPYDATA` message
+    title: Out of bounds-read when parsing a "WM_COPYDATA" message
     impact: moderate
     reporter: Ronald Crane
     description: |

--- a/announce/2021/mfsa2021-38.yml
+++ b/announce/2021/mfsa2021-38.yml
@@ -23,7 +23,7 @@ advisories:
     bugs:
       - url: 1551886
   CVE-2021-38492:
-    title: 'Navigating to `mk:` URL scheme could load Internet Explorer'
+    title: 'Navigating to "mk:" URL scheme could load Internet Explorer'
     impact: moderate
     reporter: James Lee
     description: |

--- a/announce/2021/mfsa2021-39.yml
+++ b/announce/2021/mfsa2021-39.yml
@@ -6,7 +6,7 @@ fixed_in:
 title: Security Vulnerabilities fixed in Firefox ESR 78.14
 advisories:
   CVE-2021-38492:
-    title: 'Navigating to `mk:` URL scheme could load Internet Explorer'
+    title: 'Navigating to "mk:" URL scheme could load Internet Explorer'
     impact: moderate
     reporter: James Lee
     description: |

--- a/announce/2021/mfsa2021-40.yml
+++ b/announce/2021/mfsa2021-40.yml
@@ -6,7 +6,7 @@ fixed_in:
 title: Security Vulnerabilities fixed in Firefox ESR 91.1
 advisories:
   CVE-2021-38492:
-    title: 'Navigating to `mk:` URL scheme could load Internet Explorer'
+    title: 'Navigating to "mk:" URL scheme could load Internet Explorer'
     impact: moderate
     reporter: James Lee
     description: |

--- a/announce/2021/mfsa2021-41.yml
+++ b/announce/2021/mfsa2021-41.yml
@@ -6,7 +6,7 @@ fixed_in:
 title: Security Vulnerabilities fixed in Thunderbird 91.1
 advisories:
   CVE-2021-38492:
-    title: 'Navigating to `mk:` URL scheme could load Internet Explorer'
+    title: 'Navigating to "mk:" URL scheme could load Internet Explorer'
     impact: moderate
     reporter: James Lee
     description: |

--- a/announce/2021/mfsa2021-42.yml
+++ b/announce/2021/mfsa2021-42.yml
@@ -6,7 +6,7 @@ fixed_in:
 title: Security Vulnerabilities fixed in Thunderbird 78.14
 advisories:
   CVE-2021-38492:
-    title: 'Navigating to `mk:` URL scheme could load Internet Explorer'
+    title: 'Navigating to "mk:" URL scheme could load Internet Explorer'
     impact: moderate
     reporter: James Lee
     description: |

--- a/announce/2022/mfsa2022-24.yml
+++ b/announce/2022/mfsa2022-24.yml
@@ -24,7 +24,7 @@ advisories:
     bugs:
       - url: 1765951
   CVE-2022-34468:
-    title: 'CSP sandbox header without `allow-scripts` can be bypassed via retargeted javascript: URI'
+    title: 'CSP sandbox header without "allow-scripts" can be bypassed via retargeted javascript: URI'
     impact: high
     reporter: Armin Ebert
     description: |

--- a/announce/2022/mfsa2022-25.yml
+++ b/announce/2022/mfsa2022-25.yml
@@ -24,7 +24,7 @@ advisories:
     bugs:
       - url: 1765951
   CVE-2022-34468:
-    title: 'CSP sandbox header without `allow-scripts` can be bypassed via retargeted javascript: URI'
+    title: 'CSP sandbox header without "allow-scripts" can be bypassed via retargeted javascript: URI'
     impact: high
     reporter: Armin Ebert
     description: |

--- a/announce/2022/mfsa2022-26.yml
+++ b/announce/2022/mfsa2022-26.yml
@@ -26,7 +26,7 @@ advisories:
     bugs:
       - url: 1765951
   CVE-2022-34468:
-    title: 'CSP sandbox header without `allow-scripts` can be bypassed via retargeted javascript: URI'
+    title: 'CSP sandbox header without "allow-scripts" can be bypassed via retargeted javascript: URI'
     impact: high
     reporter: Armin Ebert
     description: |

--- a/announce/2022/mfsa2022-28.yml
+++ b/announce/2022/mfsa2022-28.yml
@@ -30,7 +30,7 @@ advisories:
     bugs:
       - url: 1771774
   CVE-2022-36314:
-    title: Opening local <code>.lnk</code> files could cause unexpected network loads
+    title: Opening local ".lnk" files could cause unexpected network loads
     impact: moderate
     reporter: akucybersec
     description: |

--- a/announce/2022/mfsa2022-30.yml
+++ b/announce/2022/mfsa2022-30.yml
@@ -22,7 +22,7 @@ advisories:
     bugs:
       - url: 1771774
   CVE-2022-36314:
-    title: Opening local <code>.lnk</code> files could cause unexpected network loads
+    title: Opening local ".lnk" files could cause unexpected network loads
     impact: moderate
     reporter: akucybersec
     description: |

--- a/announce/2022/mfsa2022-32.yml
+++ b/announce/2022/mfsa2022-32.yml
@@ -24,7 +24,7 @@ advisories:
     bugs:
       - url: 1771774
   CVE-2022-36314:
-    title: Opening local <code>.lnk</code> files could cause unexpected network loads
+    title: Opening local ".lnk" files could cause unexpected network loads
     impact: moderate
     reporter: akucybersec
     description: |

--- a/announce/2023/mfsa2023-22.yml
+++ b/announce/2023/mfsa2023-22.yml
@@ -78,7 +78,7 @@ advisories:
     bugs:
       - url: 1837675
   CVE-2023-37209:
-    title: Use-after-free in `NotifyOnHistoryReload`
+    title: Use-after-free in "NotifyOnHistoryReload"
     impact: moderate
     reporter: Simon Descarpentries
     description: |

--- a/foundation_security_advisories/common_cve.py
+++ b/foundation_security_advisories/common_cve.py
@@ -162,9 +162,10 @@ def try_update_published_cve(local_cve: CVEAdvisory, local_date: int, remote_dat
     if local_cve.year < 2023:
         if not prompt_yes_no(
             f"\nThis CVE lies before the cutoff year 2023. Should the content still be updated for {local_cve.id}?",
-            default=True,  # CHANGEME
+            default=False,
         ):
             print(f"Skipping {local_cve.id} because it lies before the cutoff year")
+            touch_cve_id(local_cve.id)
             return False
     else:
         if not prompt_yes_no(f"\nShould this content be updated for {local_cve.id}?"):


### PR DESCRIPTION
- Check that the title doesn't contain `<code>` tags or backticks
- Check that titles which contain a colon are surrounded by quotes
- Check that the description only contains basic html tags that should be used for formatting the description

Closes https://github.com/mozilla/foundation-security-advisories/issues/136