### PR TITLE
Add additional check to prevent duplicate references

### DIFF
--- a/foundation_security_advisories/common_cve.py
+++ b/foundation_security_advisories/common_cve.py
@@ -116,11 +116,17 @@ def try_update_published_cve(local_cve: CVEAdvisory, local_date: int, remote_dat
     if "x_legacyV4Record" in remote_cve_json_container:
         remote_cve_json_container.pop("x_legacyV4Record")
     local_cve_json = local_cve.to_json_5_0()
+    local_reference_urls = [
+        local_reference[0]
+        for local_instance in local_cve.instances
+        for local_reference in local_instance.references
+    ]
     # If there are references which we did not add automatically, we probably don't
     # want to remove them, so we move them to our to-be-published object.
     remote_extra_references = list(
         filter(
-            lambda reference: all(
+            lambda reference: not reference["url"] in local_reference_urls
+            and all(
                 not reference["url"].startswith(prefix)
                 for prefix in [
                     "https://bugzilla.mozilla.org",


### PR DESCRIPTION
If CVE services already have a reference with the same url as one that we have locally, do not add it again. This should prevent future issues like this failed CI run: https://github.com/mozilla/foundation-security-advisories/actions/runs/8756949809/job/24034559124 (I have already corrected this particular problem manually).