### PR TITLE
Update Thunderbird announcement description field

### DIFF
--- a/announce/2025/mfsa2025-10.yml
+++ b/announce/2025/mfsa2025-10.yml
@@ -5,7 +5,7 @@ fixed_in:
 - Thunderbird 128.7
 title: Security Vulnerabilities fixed in Thunderbird ESR 128.7
 description: |
-  *In general, these flaws cannot be exploited through email in the Thunderbird product because scripting is disabled when reading mail, but are potentially risks in browser or browser-like contexts.*
+  *Flaws inherited from the Firefox code base are generally not exploitable through email in Thunderbird, as scripting is disabled when reading mail. However, they may pose risks in browser or browser-like environments.*
 advisories:
   CVE-2025-1009:
     title: Use-after-free in XSLT


### PR DESCRIPTION
Modify the description field to be more of a general note that inherited Firefox advisories may not affect Thunderbird. The previous wording may have given the impression that none of the advisories affected Thunderbird.

With advisories from Firefox and Thunderbird mixed together, this will help convey to users that the advisories may affect Thunderbird.