### PR TITLE
Clarify browser contexts in Thunderbird description

### DIFF
--- a/announce/2025/mfsa2025-10.yml
+++ b/announce/2025/mfsa2025-10.yml
@@ -5,7 +5,7 @@ fixed_in:
 - Thunderbird 128.7
 title: Security Vulnerabilities fixed in Thunderbird ESR 128.7
 description: |
-  *Flaws inherited from the Firefox code base are generally not exploitable through email in Thunderbird, as scripting is disabled when reading mail. However, they may pose risks in browser or browser-like environments.*
+  *Flaws inherited from the Firefox code base are generally not exploitable through email in Thunderbird, as scripting is disabled when reading mail. However, they may pose a risk in other features that display remote web content.*
 advisories:
   CVE-2025-1009:
     title: Use-after-free in XSLT

--- a/announce/2025/mfsa2025-11.yml
+++ b/announce/2025/mfsa2025-11.yml
@@ -5,7 +5,7 @@ fixed_in:
 - Thunderbird 135
 title: Security Vulnerabilities fixed in Thunderbird 135
 description: |
-  *In general, these flaws cannot be exploited through email in the Thunderbird product because scripting is disabled when reading mail, but are potentially risks in browser or browser-like contexts.*
+  *Flaws inherited from the Firefox code base are generally not exploitable through email in Thunderbird, as scripting is disabled when reading mail. However, they may pose a risk in other features that display remote web content.*
 advisories:
   CVE-2025-1009:
     title: Use-after-free in XSLT


### PR DESCRIPTION
The use of "browser or browser-like environments" and "browser or browser-like contexts" could lead to confusion among users. This makes that sentence more clear.

This also adds the description update to the latest Thunderbird monthly release in mfsa2025-11.yml.

Thanks to Dan Veditz for the suggestion.