### PR TITLE
Thunderbird does not use ESR probably

### DIFF
--- a/announce/2025/mfsa2025-24.yml
+++ b/announce/2025/mfsa2025-24.yml
@@ -2,7 +2,7 @@
 announced: April 1, 2025
 impact: high
 fixed_in:
-- Thunderbird ESR 128.9
+- Thunderbird 128.9
 title: Security Vulnerabilities fixed in Thunderbird ESR 128.9
 advisories:
   CVE-2025-3028:


### PR DESCRIPTION
Unlike Firefox, Thunderbird doesn't seem to use ESR for 128 versions. cf https://github.com/mozilla/foundation-security-advisories/blob/f53088fa08e0b80226a41f69cc592229e6215908/announce/2025/mfsa2025-18.yml#L5C1-L5C20