### PR TITLE
Fix issues caused by CVE-2025-5262

### DIFF
--- a/announce/2025/mfsa2025-45.yml
+++ b/announce/2025/mfsa2025-45.yml
@@ -7,7 +7,7 @@ title: Security Vulnerabilities fixed in Thunderbird 139
 description: |
   *In general, these flaws cannot be exploited through email in the Thunderbird product because scripting is disabled when reading mail, but are potentially risks in browser or browser-like contexts.*
 advisories:
-  CVE-2025-5262:
+  CVE-2025-5283:
     title: Double-free in libvpx encoder
     impact: critical
     reporter: Randell Jesup

--- a/announce/2025/mfsa2025-46.yml
+++ b/announce/2025/mfsa2025-46.yml
@@ -7,7 +7,7 @@ title: Security Vulnerabilities fixed in Thunderbird 128.11
 description: |
   *In general, these flaws cannot be exploited through email in the Thunderbird product because scripting is disabled when reading mail, but are potentially risks in browser or browser-like contexts.*
 advisories:
-  CVE-2025-5262:
+  CVE-2025-5283:
     title: Double-free in libvpx encoder
     impact: critical
     reporter: Randell Jesup

--- a/foundation_security_advisories/common_cve.py
+++ b/foundation_security_advisories/common_cve.py
@@ -220,9 +220,12 @@ def get_owned_cve_ids():
     owned_ids = []
     print("-> Fetching already owned CVE-IDs")
     for cve_advisory in cve_api.list_cves():
+        if cve_advisory["state"] == "REJECTED":
+            # If we have rejected a CVE, we don't want to publish it again.
+            continue
         cve_id = cve_advisory["cve_id"]
         owned_ids.append(cve_id)
-        if cve_advisory["state"] == "PUBLISHED" or cve_advisory["state"] == "REJECTED":
+        if cve_advisory["state"] == "PUBLISHED":
             published_dates[cve_id] = parse_iso_date(
                 cve_advisory["time"]["modified"])
         elif cve_advisory["state"] == "RESERVED":

--- a/foundation_security_advisories/common_cve.py
+++ b/foundation_security_advisories/common_cve.py
@@ -141,10 +141,10 @@ def try_update_published_cve(local_cve: CVEAdvisory, local_date: int, remote_dat
         )
         local_cve_json["containers"]["cna"]["references"].extend(
             remote_extra_references)
-    # Sort the references to make sure we detect the diff correctly.
-    remote_cve_json["containers"]["cna"]["references"].sort(
-        key=lambda reference: reference["url"]
-    )
+        # Sort the references to make sure we detect the diff correctly.
+        remote_cve_json["containers"]["cna"]["references"].sort(
+            key=lambda reference: reference["url"]
+        )
     local_cve_json["containers"]["cna"]["references"].sort(
         key=lambda reference: reference["url"]
     )
@@ -181,7 +181,8 @@ def try_update_published_cve(local_cve: CVEAdvisory, local_date: int, remote_dat
             f"\nThis CVE lies before the cutoff year 2023. Should the content still be updated for {local_cve.id}?",
             default=False,
         ):
-            print(f"Skipping {local_cve.id} because it lies before the cutoff year")
+            print(
+                f"Skipping {local_cve.id} because it lies before the cutoff year")
             touch_cve_id(local_cve.id)
             return False
     else:
@@ -222,7 +223,8 @@ def get_owned_cve_ids():
         cve_id = cve_advisory["cve_id"]
         owned_ids.append(cve_id)
         if cve_advisory["state"] == "PUBLISHED" or cve_advisory["state"] == "REJECTED":
-            published_dates[cve_id] = parse_iso_date(cve_advisory["time"]["modified"])
+            published_dates[cve_id] = parse_iso_date(
+                cve_advisory["time"]["modified"])
         elif cve_advisory["state"] == "RESERVED":
             continue
         else:
@@ -334,7 +336,8 @@ def get_local_cve_advisories():
                 cve_data = file_data["advisories"][cve_id]
                 if cve_id not in local_advisories:
                     year = int(cve_id.split("-")[-2])
-                    local_advisories[cve_id] = CVEAdvisory(id=cve_id, year=year)
+                    local_advisories[cve_id] = CVEAdvisory(
+                        id=cve_id, year=year)
                 for fixed_in in file_data["fixed_in"]:
                     product, version_fixed = fixed_in.rsplit(None, 1)
                     references = [parse_bug(bug) for bug in cve_data["bugs"]]


### PR DESCRIPTION
We still have some issues with publishing CVEs that I wasn't able to fix in #157. These all stem from CVE-2025-5262, where we accidentally reserved and published a CVE and rejected it afterward.

- Fix a second possibly undefined key I missed in https://github.com/mozilla/foundation-security-advisories/pull/157
- If we own a CVE, but it is rejected like is the case with CVE-2025-5262, do not try to publish it
- Finally, also replace the rejected CVE-2025-5262 with CVE-2025-5283