### PR TITLE
Change "mac OS" to "macOS" in mfsa2024-29.yml

### DIFF
--- a/announce/2024/mfsa2024-29.yml
+++ b/announce/2024/mfsa2024-29.yml
@@ -72,7 +72,7 @@ advisories:
     impact: moderate
     reporter: pwn2car
     description: |
-      Due to large allocation checks in Angle for GLSL shaders being too lenient an out-of-bounds access could occur when allocating more than 8192 ints in private shader memory on mac OS.
+      Due to large allocation checks in Angle for GLSL shaders being too lenient an out-of-bounds access could occur when allocating more than 8192 ints in private shader memory on macOS.
     bugs:
       - url: 1888340
   CVE-2024-6601:


### PR DESCRIPTION
The OS is either actually called "macOS" or in the old variant with spaces as "Mac OS X". As newer advisories using "macOS" adjusting the file accordingly for consistency reasons.