### PR TITLE
Fix mixed up advisory IDs / names for Thunderbird.

### DIFF
--- a/announce/2026/mfsa2026-62.yml
+++ b/announce/2026/mfsa2026-62.yml
@@ -1,0 +1,25 @@
+## mfsa2026-62.yml
+announced: June 30, 2026
+impact: high
+fixed_in:
+- Thunderbird 152.0.1
+title: Security Vulnerabilities fixed in Thunderbird 152.0.1
+description: |
+  *In general, these flaws cannot be exploited through email in the Thunderbird product because scripting is disabled when reading mail, but are potentially risks in browser or browser-like contexts.*
+advisories:
+  CVE-2026-57962:
+    title: Denial-of-service via malicious LDAP address-book server
+    impact: medium
+    reporter: Michael Bommarito
+    description: |
+      A malicious LDAP server, which a Thunderbird user is configured to query for address-book autocomplete, can stash arbitrarily large amounts of attacker-supplied data into the Thunderbird LDAP client until it crashes due to memory exhaustion.
+    bugs:
+      - url: 2042872
+  CVE-2026-57963:
+    title: Chat UI manipulation by injection
+    impact: high
+    reporter: Michael Bommarito
+    description: |
+      An attacker who can send HTML chat messages (via Matrix or XMPP) can inject arbitrary styled content, phishing links, and CSS that manipulates the chat UI.
+    bugs:
+      - url: 2042910

--- a/announce/2026/mfsa2026-63.yml
+++ b/announce/2026/mfsa2026-63.yml
@@ -1,9 +1,9 @@
-# mfsa2026-63.yml
+## mfsa2026-63.yml
 announced: June 30, 2026
 impact: high
 fixed_in:
-- Thunderbird 140.12.1
-title: Security Vulnerabilities fixed in Thunderbird 140.12.1
+- Thunderbird 152.0.1
+title: Security Vulnerabilities fixed in Thunderbird 152.0.1
 description: |
   *In general, these flaws cannot be exploited through email in the Thunderbird product because scripting is disabled when reading mail, but are potentially risks in browser or browser-like contexts.*
 advisories:

--- a/announce/2026/mfsa2026-63.yml
+++ b/announce/2026/mfsa2026-63.yml
@@ -1,0 +1,25 @@
+# mfsa2026-63.yml
+announced: June 30, 2026
+impact: high
+fixed_in:
+- Thunderbird 140.12.1
+title: Security Vulnerabilities fixed in Thunderbird 140.12.1
+description: |
+  *In general, these flaws cannot be exploited through email in the Thunderbird product because scripting is disabled when reading mail, but are potentially risks in browser or browser-like contexts.*
+advisories:
+  CVE-2026-57962:
+    title: Denial-of-service via malicious LDAP address-book server
+    impact: medium
+    reporter: Michael Bommarito
+    description: |
+      A malicious LDAP server, which a Thunderbird user is configured to query for address-book autocomplete, can stash arbitrarily large amounts of attacker-supplied data into the Thunderbird LDAP client until it crashes due to memory exhaustion.
+    bugs:
+      - url: 2042872
+  CVE-2026-57963:
+    title: Chat UI manipulation by injection
+    impact: high
+    reporter: Michael Bommarito
+    description: |
+      An attacker who can send HTML chat messages (via Matrix or XMPP) can inject arbitrary styled content, phishing links, and CSS that manipulates the chat UI.
+    bugs:
+      - url: 2042910

--- a/announce/2026/mfsa2026-64.yml
+++ b/announce/2026/mfsa2026-64.yml
@@ -1,9 +1,9 @@
-## mfsa2026-62.yml
+## mfsa2026-64.yml
 announced: June 30, 2026
 impact: high
 fixed_in:
-- Thunderbird 152.0.1
-title: Security Vulnerabilities fixed in Thunderbird 152.0.1
+- Thunderbird 140.12.1
+title: Security Vulnerabilities fixed in Thunderbird 140.12.1
 description: |
   *In general, these flaws cannot be exploited through email in the Thunderbird product because scripting is disabled when reading mail, but are potentially risks in browser or browser-like contexts.*
 advisories:


### PR DESCRIPTION
Fixes the file names of the new advisories from 0c1c7ab0df65b2226012b7604ad210d2a0a4c8d1 to match the published info here (which is the source of truth now according to #182):
- https://www.mozilla.org/en-US/security/advisories/mfsa2026-63/ (`Mozilla Foundation Security Advisory 2026-63 - Security Vulnerabilities fixed in Thunderbird 152.0.1`)
- https://www.mozilla.org/en-US/security/advisories/mfsa2026-64/ (`Mozilla Foundation Security Advisory 2026-64 Security Vulnerabilities fixed in Thunderbird 140.12.1`)

Note: Even if the repo seems to get phased out (see comment in #182) i guess it makes sense to have the current file names fixed to avoid confusion etc.

cc @coreycb @simon-friedberger FYI